### PR TITLE
Add necessary packages to requirements.txt

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,3 +1,4 @@
+django
 ujson
 xml_marshaller
 six
@@ -12,3 +13,9 @@ python-ldap
 MySQL-python
 reportlab
 bitarray
+python-dateutil
+defusedxml
+requests
+xenapi
+geraldo
+pycha


### PR DESCRIPTION
This does not include `pycairo`, as it does not provide an egg and therefore can't be installed via pip.
We should consider [`cairocffi`](https://stackoverflow.com/questions/11491268/install-pycairo-in-virtualenv) instead, but `pycha` (last update 2013) would have to be patched then.

STR: cd into `server/src`, call `pip install -r ../requirements.txt` and try to run `python migrate.py help`, which will throw an `ImportError`. Add missing package to `requirements.txt` and repeat.