### PR TITLE
Update to latest Guacamole API versions.

### DIFF
--- a/guacamole-tunnel/pom.xml
+++ b/guacamole-tunnel/pom.xml
@@ -81,14 +81,14 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-common</artifactId>
-            <version>0.9.9-incubating</version>
+            <version>0.9.10-incubating</version>
         </dependency>
 
         <!-- Guacamole JavaScript library -->
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-common-js</artifactId>
-            <version>0.9.9-incubating</version>
+            <version>0.9.12-incubating</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>


### PR DESCRIPTION
This change updates the versions of guacamole-common and guacamole-common-js to the latest of each (as of [the upstream 0.9.12-incubating release](http://guacamole.incubator.apache.org/releases/0.9.12-incubating/)). The version of guacamole-common is only increasing to 0.9.10-incubating here as that library has not changed since 0.9.10-incubating.

I've checked that there are no API or behavior changes which would break UDS, and have deployed and retested the Guacamole tunnel portion of UDS to verify.