### PR TITLE
Update to 0.9.14 version of Apache Guacamole APIs.

### DIFF
--- a/guacamole-tunnel/pom.xml
+++ b/guacamole-tunnel/pom.xml
@@ -81,14 +81,14 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-common</artifactId>
-            <version>0.9.10-incubating</version>
+            <version>0.9.14</version>
         </dependency>
 
         <!-- Guacamole JavaScript library -->
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-common-js</artifactId>
-            <version>0.9.12-incubating</version>
+            <version>0.9.14</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>

--- a/guacamole-tunnel/src/main/webapp/scripts/client-ui.js
+++ b/guacamole-tunnel/src/main/webapp/scripts/client-ui.js
@@ -51,6 +51,12 @@ GuacUI.Client = {
         0x0205: "This connection is currently in use, and concurrent access to \
                  this connection is not allowed. Please try again later.",
 
+        0x0207: "The Guacamole server is not currently reachable. Please \
+                 check your network and try again.",
+
+        0x0208: "The Guacamole server is not accepting connections. Please \
+                 check your network and try again.",
+
         0x0301: "You do not have permission to access this connection because \
                  you are not logged in. Please log in and try again.",
 
@@ -94,14 +100,32 @@ GuacUI.Client = {
                  the connection. Please try again or contact your system       \
                  administrator.",
 
-        0x0205: "This connection has been closed because it conflicts with \
-                 another connection. Please try again later.",
+        0x0207: "The remote desktop server is currently unreachable. If the    \
+                 problem persists, please notify your system administrator, or \
+                 check your system logs.",
+
+        0x0208: "The remote desktop server is currently unavailable. If the    \
+                 problem persists, please notify your system administrator, or \
+                 check your system logs.",
+
+        0x0209: "The remote desktop server has closed the connection because   \
+                 it conflicts with another connection. Please try again later.",
+
+        0x020A: "The remote desktop server has closed the connection because   \
+                 it appeared to be inactive. If this is undesired or           \
+                 unexpected, please notify your system administrator, or check \
+                 your system settings.",
+
+        0x020B: "The remote desktop server has forcibly closed the connection. \
+                 If this is undesired or unexpected, please notify your system \
+                 administrator, or check your system logs.",
 
         0x0301: "Log in failed. Please reconnect and try again.",
 
-        0x0303: "You do not have permission to access this connection. If you \
-                 require access, please ask your system administrator to add  \
-                 you the list of allowed users, or check your system settings.",
+        0x0303: "The remote desktop server has denied access to this          \
+                 connection. If you require access, please ask your system    \
+                 administrator to grant your account access, or check your    \
+                 system settings.",
 
         0x0308: "The Guacamole server has closed the connection because there \
                  has been no response from your browser for long enough that  \

--- a/guacamole-tunnel/src/main/webapp/scripts/client-ui.js
+++ b/guacamole-tunnel/src/main/webapp/scripts/client-ui.js
@@ -203,6 +203,8 @@ GuacUI.Client = {
         0x0200: true,
         0x0202: true,
         0x0203: true,
+        0x0207: true,
+        0x0208: true,
         0x0308: true
     },
 
@@ -214,6 +216,8 @@ GuacUI.Client = {
         0x0200: true,
         0x0202: true,
         0x0203: true,
+        0x0207: true,
+        0x0208: true,
         0x0301: true,
         0x0308: true
     },


### PR DESCRIPTION
These changes update the OpenUDS build to use the 0.9.14 of the Apache Guacamole APIs (the latest release).

In general, no changes were necessary due strictly to the upgrade (guacamole-common and guacamole-common-js have not broken API compatibility), however updates to the defined error strings and reconnect behavior were necessary to take new error codes into account. These changes are analogous to the following upstream commits:

* apache/guacamole-client@dd6964a and apache/guacamole-client@ee4f8cf (which define human-readable strings for the new error codes)
* apache/guacamole-client@ecf506e (which specifies that automatic reconnect should occur after network errors)

The above error code changes will only have an effect if the version of guacamole-server is also up-to-date, as older releases do not have these new codes.