### PR TITLE
Use Guacamole.AudioPlayer and Guacamole.VideoPlayer to query the audio/video mimetypes supported by the Apache Guacamole client.

### DIFF
--- a/guacamole-tunnel/src/main/webapp/scripts/guac-ui.js
+++ b/guacamole-tunnel/src/main/webapp/scripts/guac-ui.js
@@ -97,53 +97,15 @@ GuacUI.removeClass = function(element, classname) {
  */
 GuacUI.Audio = new (function() {
 
-    var codecs = [
-        'audio/ogg; codecs="vorbis"',
-        'audio/mp4; codecs="mp4a.40.5"',
-        'audio/mpeg; codecs="mp3"',
-        'audio/webm; codecs="vorbis"',
-        'audio/wav; codecs=1'
-    ];
-
-    var probably_supported = [];
-    var maybe_supported = [];
-
     /**
      * Array of all supported audio mimetypes, ordered by liklihood of
      * working.
      */
-    this.supported = [];
+    this.supported = Guacamole.AudioPlayer.getSupportedTypes();
 
-    // If sound disabled, we're done now.
+    // If sound disabled, declare that no types are supported
     if (GuacamoleSessionStorage.getItem("disable-sound", false))
-        return;
-    
-    // Build array of supported audio formats
-    codecs.forEach(function(mimetype) {
-
-        var audio = new Audio();
-        var support_level = audio.canPlayType(mimetype);
-
-        // Trim semicolon and trailer
-        var semicolon = mimetype.indexOf(";");
-        if (semicolon != -1)
-            mimetype = mimetype.substring(0, semicolon);
-
-        // Partition by probably/maybe
-        if (support_level == "probably")
-            probably_supported.push(mimetype);
-        else if (support_level == "maybe")
-            maybe_supported.push(mimetype);
-
-    });
-
-    // Add probably supported types first
-    Array.prototype.push.apply(
-        this.supported, probably_supported);
-
-    // Prioritize "maybe" supported types second
-    Array.prototype.push.apply(
-        this.supported, maybe_supported);
+        this.supported = [];
 
 })();
 
@@ -152,48 +114,12 @@ GuacUI.Audio = new (function() {
  */
 GuacUI.Video = new (function() {
 
-    var codecs = [
-        'video/ogg; codecs="theora, vorbis"',
-        'video/mp4; codecs="avc1.4D401E, mp4a.40.5"',
-        'video/webm; codecs="vp8.0, vorbis"'
-    ];
-
-    var probably_supported = [];
-    var maybe_supported = [];
-
     /**
      * Array of all supported video mimetypes, ordered by liklihood of
      * working.
      */
-    this.supported = [];
+    this.supported = Guacamole.VideoPlayer.getSupportedTypes();
     
-    // Build array of supported audio formats
-    codecs.forEach(function(mimetype) {
-
-        var video = document.createElement("video");
-        var support_level = video.canPlayType(mimetype);
-
-        // Trim semicolon and trailer
-        var semicolon = mimetype.indexOf(";");
-        if (semicolon != -1)
-            mimetype = mimetype.substring(0, semicolon);
-
-        // Partition by probably/maybe
-        if (support_level == "probably")
-            probably_supported.push(mimetype);
-        else if (support_level == "maybe")
-            maybe_supported.push(mimetype);
-
-    });
-
-    // Add probably supported types first
-    Array.prototype.push.apply(
-        this.supported, probably_supported);
-
-    // Prioritize "maybe" supported types second
-    Array.prototype.push.apply(
-        this.supported, maybe_supported);
-
 })();
 
 /**


### PR DESCRIPTION
The various parts of the Apache Guacamole stack expect different mimetypes to be available since around 0.9.9, and the `Guacamole.AudioPlayer` and `Guacamole.VideoPlayer` objects are used to retrieve the mimetypes that are supported by the client and should be sent to the server.

This change replaces the legacy `GuacUI.Audio` and `GuacUI.Video` checks for support with calls to `Guacamole.AudioPlayer.getSupportedTypes()` and `Guacamole.VideoPlayer.getSupportedTypes()`. This is essentially what is done upstream for the mainline Guacamole webapp:

https://github.com/apache/guacamole-client/blob/1623f55191d0486b59fffd216fc2ae0d2cc57021/guacamole/src/main/webapp/app/client/services/guacAudio.js#L35

https://github.com/apache/guacamole-client/blob/1623f55191d0486b59fffd216fc2ae0d2cc57021/guacamole/src/main/webapp/app/client/services/guacVideo.js#L33