### PR TITLE
Fix Error 500: Plaintext too large on Tools/Configure page.

### DIFF
--- a/server/src/uds/core/util/Config.py
+++ b/server/src/uds/core/util/Config.py
@@ -75,7 +75,7 @@ class Config:
             self._key: str = key
             self._crypt: bool = crypt
             self._longText: bool = longText
-            if crypt is False:
+            if crypt is False or not default:
                 self._default: str = default
             else:
                 self._default = CryptoManager.manager().encrypt(default)


### PR DESCRIPTION
ERROR 2019-07-17 17:48:11,302 __init__ dispatch 163 Error processing request
Traceback (most recent call last):
  File "/usr/share/openuds/uds/REST/__init__.py", line 143, in dispatch
    response = operation()
  File "/usr/share/openuds/uds/REST/methods/config.py", line 61, in get
    for cfg in CfgConfig.enumerate():
  File "/usr/share/openuds/uds/core/util/Config.py", line 210, in enumerate
    val = Config.section(cfg.section).valueCrypt(cfg.key)
  File "/usr/share/openuds/uds/core/util/Config.py", line 185, in valueCrypt
    return Config.value(self, key, default, True, **kwargs)
  File "/usr/share/openuds/uds/core/util/Config.py", line 199, in value
    return Config.Value(section, key, default, crypt, longText, **kwargs)
  File "/usr/share/openuds/uds/core/util/Config.py", line 82, in __init__
    self._default = CryptoManager.manager().encrypt(default)
  File "/usr/share/openuds/uds/core/managers/CryptoManager.py", line 98, in encrypt
    return encoders.encode((self._rsa.encrypt(value, b'')[0]), 'base64', asText=True)
  File "/usr/lib64/python3/site-packages/Crypto/PublicKey/RSA.py", line 158, in encrypt
    return pubkey.pubkey.encrypt(self, plaintext, K)
  File "/usr/lib64/python3/site-packages/Crypto/PublicKey/pubkey.py", line 75, in encrypt
    ciphertext=self._encrypt(plaintext, K)
  File "/usr/lib64/python3/site-packages/Crypto/PublicKey/RSA.py", line 233, in _encrypt
    raise ValueError("Plaintext too large")
ValueError: Plaintext too large

Fixes: #44