### PR TITLE
Leverage Guacamole.InputSink for dead key support.

### DIFF
--- a/guacamole-tunnel/pom.xml
+++ b/guacamole-tunnel/pom.xml
@@ -81,14 +81,14 @@
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-common</artifactId>
-            <version>0.9.14</version>
+            <version>1.0.0</version>
         </dependency>
 
         <!-- Guacamole JavaScript library -->
         <dependency>
             <groupId>org.apache.guacamole</groupId>
             <artifactId>guacamole-common-js</artifactId>
-            <version>0.9.14</version>
+            <version>1.0.0</version>
             <type>zip</type>
             <scope>runtime</scope>
         </dependency>

--- a/guacamole-tunnel/src/main/webapp/scripts/client-ui.js
+++ b/guacamole-tunnel/src/main/webapp/scripts/client-ui.js
@@ -1433,7 +1433,11 @@ GuacUI.Client.attach = function(guac) {
      * Route document-level keyboard events to the client.
      */
 
+    var sink = new Guacamole.InputSink();
+    document.body.appendChild(sink.getElement());
+
     var keyboard = new Guacamole.Keyboard(document);
+    keyboard.listenTo(sink.getElement());
     var show_keyboard_gesture_possible = true;
 
     function __send_key(pressed, keysym) {


### PR DESCRIPTION
The [`Guacamole.InputSink`](http://guacamole.apache.org/doc/1.0.0/guacamole-common-js/Guacamole.InputSink.html) object was added to guacamole-common-js as part of the 1.0.0 release of Apache Guacamole, allowing composed key events to be handled with `Guacamole.Keyboard` as any other keys would:

http://guacamole.apache.org/releases/1.0.0/#improved-keyboard-handling--support-for-dead-keys

This change adds an instance of `Guacamole.InputSink` to the document body, additionally pointing the existing `Guacamole.Keyboard` at that element (in addition to `document`).

This is analogous to the way `Guacamole.InputSink` and `Guacamole.Keyboard` are used within Apache Guacamole itself, as of [GUACAMOLE-352](https://issues.apache.org/jira/browse/GUACAMOLE-352):

https://github.com/apache/guacamole-client/blob/bad20e1a6cd56453f2ee1c27255bb3485925b437/guacamole/src/main/webapp/app/index/controllers/indexController.js#L93-L99