### PR TITLE
fix for proper escaping of conflicting chars in rdp credential redire…

### DIFF
--- a/server/src/uds/transports/RDP/rdp.py
+++ b/server/src/uds/transports/RDP/rdp.py
@@ -105,6 +105,9 @@ class RDPTransport(BaseRDPTransport):
         ci = self.getConnectionInfo(userService, user, password)
         username, password, domain = ci['username'], ci['password'], ci['domain']
 
+        # escape conflicting chars
+        password = password.replace('\\', '\\\\').replace('"', '\\"').replace("'", "\\'")
+
         # width, height = CommonPrefs.getWidthHeight(prefs)
         # depth = CommonPrefs.getDepth(prefs)
         width, height = self.screenSize.value.split('x')

--- a/server/src/uds/transports/RDP/rdptunnel.py
+++ b/server/src/uds/transports/RDP/rdptunnel.py
@@ -124,6 +124,9 @@ class TRDPTransport(BaseRDPTransport):
         ci = self.getConnectionInfo(userService, user, password)
         username, password, domain = ci['username'], ci['password'], ci['domain']
 
+        # escape conflicting chars
+        password = password.replace('\\', '\\\\').replace('"', '\\"').replace("'", "\\'")
+
         # width, height = CommonPrefs.getWidthHeight(prefs)
         # depth = CommonPrefs.getDepth(prefs)
         width, height = self.screenSize.value.split('x')


### PR DESCRIPTION
…ction

This avoid errors in client-side with user passwords starting and/or ending by one of these chars: backslash, single quote, double quote.