### PR TITLE
Add checkbox to enable SSL connection for SPICE

### DIFF
--- a/server/src/uds/transports/SPICE/remote_viewer_file.py
+++ b/server/src/uds/transports/SPICE/remote_viewer_file.py
@@ -67,6 +67,7 @@ class RemoteViewerFile:
     new_usb_auto_share: bool = False
     delete_file: bool = True
     proxy: str = ''
+    ssl_connection: bool = False
 
     def __init__(
         self,
@@ -103,6 +104,7 @@ class RemoteViewerFile:
         delete_file = '01'[self.delete_file]
         usb_auto_share = '01'[self.usb_auto_share]
         new_usb_auto_share = '01'[self.new_usb_auto_share]
+        ssl_connection = '01'[self.ssl_connection]
 
         ca = self.ca.strip().replace(
             '\n', '\\n'
@@ -125,7 +127,7 @@ class RemoteViewerFile:
             host_subject=self.host_subject if tls_port != '-1' else '',
             ca=ca if tls_port != '-1' else '',
             secure_channel='secure-channels=main;inputs;cursor;playback;record;display;usbredir;smartcard'
-            if tls_port != '-1'
+            if ssl_connection and tls_port != '-1'
             else '',
             proxy=self.proxy,
         )

--- a/server/src/uds/transports/SPICE/spice.py
+++ b/server/src/uds/transports/SPICE/spice.py
@@ -67,6 +67,7 @@ class SPICETransport(BaseSpiceTransport):
     usbShare = BaseSpiceTransport.usbShare
     autoNewUsbShare = BaseSpiceTransport.autoNewUsbShare
     smartCardRedirect = BaseSpiceTransport.smartCardRedirect
+    sslConnection = BaseSpiceTransport.SSLConnection
 
     def getUDSTransportScript(
         self,
@@ -103,6 +104,7 @@ class SPICETransport(BaseSpiceTransport):
         r.usb_auto_share = self.usbShare.isTrue()
         r.new_usb_auto_share = self.autoNewUsbShare.isTrue()
         r.smartcard = self.smartCardRedirect.isTrue()
+        r.ssl = self.sslConnection.isTrue()
 
         osName = {
             OsDetector.KnownOS.Windows: 'windows',

--- a/server/src/uds/transports/SPICE/spice_base.py
+++ b/server/src/uds/transports/SPICE/spice_base.py
@@ -114,6 +114,12 @@ class BaseSpiceTransport(transports.Transport):
         defvalue=gui.FALSE,
         tab=gui.Tab.ADVANCED,
     )
+    SSLConnection = gui.CheckBoxField(
+        order=9,
+        label=_('SSL Connection'),
+        tooltip=_('If checked, SPICE protocol will required SSL connection.'),
+        defvalue=gui.FALSE,
+    )
 
     def isAvailableFor(self, userService: 'models.UserService', ip: str) -> bool:
         """


### PR DESCRIPTION
If in OpenNebula not enabled TLS for SPICE protocol, when cannot connect to OpenNebula with generated virt-viewer connection config file, because "secure-channel" options successfully work over TLS only.
This changes allow enable or disable TLS on UDS site.