### PR TITLE
Potential fix for code scanning alert no. 390: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test OpenUDS
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/VirtualCable/openuds/security/code-scanning/390](https://github.com/VirtualCable/openuds/security/code-scanning/390)

The best way to fix this problem is to explicitly add a `permissions` block that sets minimal required privileges for this workflow. For most testing workflows where you only need to check out the code and run tests, `contents: read` is sufficient. You should add the block either at the root of the workflow (to apply to all jobs) or directly under the `test` job. Since there is only a single job here, adding at the root is clear and future-proof.

Specifically, edit `.github/workflows/test.yml` and insert the following after the workflow name but before `on:` (at line 2 or 3):

```yaml
permissions:
  contents: read
```
No additional methods, imports, or definitions are needed. This edit will ensure the workflow and its jobs run with least privilege, addressing CodeQL's flagged issue.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
