### PR TITLE
Dev/andres/master req

### DIFF
--- a/server/src/uds/services/OpenShift/provider.py
+++ b/server/src/uds/services/OpenShift/provider.py
@@ -125,18 +125,6 @@ class OpenshiftProvider(ServiceProvider):
     # Utility
     def sanitized_name(self, name: str) -> str:
         """
-        Sanitizes the VM name to comply with RFC 1123:
-        - Converts to lowercase
-        - Replaces any character not in [a-z0-9.-] with '-'
-        - Collapses multiple '-' into one
-        - Removes leading/trailing non-alphanumeric characters
-        - Limits length to 63 characters
+        OpenShift only allows machine names with [a-zA-Z0-9_-]
         """
-        name = name.lower()
-        # Replace any character not allowed with '-'
-        name = re.sub(r'[^a-z0-9.-]', '-', name)
-        # Collapse multiple '-' into one
-        name = re.sub(r'-{2,}', '-', name)
-        # Remove leading/trailing non-alphanumeric characters
-        name = re.sub(r'^[^a-z0-9]+|[^a-z0-9]+$', '', name)
-        return name[:63]
+        return re.sub(r'[^a-zA-Z0-9-]', '-', name).lower()[:63]

--- a/server/tests/services/openshift/test_provider.py
+++ b/server/tests/services/openshift/test_provider.py
@@ -134,9 +134,9 @@ class TestOpenshiftProvider(UDSTransactionTestCase):
         test_cases = [
             ('Test-VM-1', 'test-vm-1'),
             ('Test_VM@2', 'test-vm-2'),
-            ('My Test VM!!!', 'my-test-vm'),
-            ('Test !!! this is', 'test-this-is'),
-            ('UDS-Pub-Hello World!!--2025065122-v1', 'uds-pub-hello-world-2025065122-v1'),
+            ('My Test VM!!!', 'my-test-vm---'),
+            ('Test !!! this is', 'test-----this-is'),
+            ('UDS-Pub-Hello World!!--2025065122-v1', 'uds-pub-hello-world----2025065122-v1'),
             ('a' * 100, 'a' * 63),  # Test truncation
         ]
         for input_name, expected in test_cases:


### PR DESCRIPTION
This pull request updates the VM name sanitization logic in the OpenShift provider to align with OpenShift's allowed character set, and adjusts the related test cases accordingly. The main change is to simplify the sanitization rules to only replace unsupported characters with hyphens and ensure lowercase, which also affects the expected outputs of the tests.

Sanitization logic update:

* Updated the `sanitized_name` method in `server/src/uds/services/OpenShift/provider.py` to only allow `[a-zA-Z0-9_-]` characters, replacing any unsupported character with a hyphen and converting the result to lowercase, limited to 63 characters.

Test adjustments:

* Modified test cases in `server/tests/services/openshift/test_provider.py` to reflect the new sanitization behavior, updating expected outputs to match the revised logic for handling unsupported characters and truncation.