### PR TITLE
Set RDP file usage default to false for Linux and Mac

### DIFF
--- a/server/src/uds/transports/RDP/rdp_base.py
+++ b/server/src/uds/transports/RDP/rdp_base.py
@@ -302,7 +302,7 @@ class BaseRDPTransport(transports.Transport):
         order=42,
         tooltip=_('If marked, an RDP file will be used for connections with Thincast or xfreerdp on Linux.'),
         tab='Linux Client',
-        default=True,
+        default=False,
         old_field_name='lnx_thincastRdpFile',
     )
     lnx_printer_string = gui.TextField(
@@ -346,7 +346,7 @@ class BaseRDPTransport(transports.Transport):
         order=51,
         tooltip=_('If marked, an RDP file will be used for connections with Thincast or xfreerdp on Mac OS X.'),
         tab='Mac OS X',
-        default=True,
+        default=False,
         old_field_name='mac_thincastRdpFile',
     )
 


### PR DESCRIPTION
Updates the default setting to not use RDP files for Thincast or xfreerdp on Linux and Mac OS X. Prevents automatic RDP file usage unless explicitly enabled, likely to better match user expectations or deployment configurations.