### PR TITLE
Dev/andres&janier/v4.0 logout unused

### DIFF
--- a/server/src/uds/osmanagers/LinuxOsManager/linux_osmanager.py
+++ b/server/src/uds/osmanagers/LinuxOsManager/linux_osmanager.py
@@ -36,6 +36,7 @@ import typing
 from django.utils.translation import gettext_noop as _
 
 from uds.core import osmanagers, types
+from uds.core.managers.userservice import UserServiceManager
 from uds.core.ui import gui
 from uds.core.util import fields, log
 from uds.core.types.states import State
@@ -115,10 +116,12 @@ class LinuxOsManager(osmanagers.OSManager):
             log.log(
                 userservice,
                 types.log.LogLevel.INFO,
-                'Unused user service for too long. Removing due to OS Manager parameters.',
+                'Unused user service for too long. Releasing (logout) due to OS Manager parameters.',
                 types.log.LogSource.OSMANAGER,
             )
-            userservice.release()
+            osmanagers.OSManager.logged_out(userservice, username='unused')
+            # release_from_logout handles cache return if pool allows it, else releases
+            UserServiceManager.manager().release_from_logout(userservice)
 
     def is_persistent(self) -> bool:
         return fields.onlogout_field_is_persistent(self.on_logout)

--- a/server/src/uds/osmanagers/WindowsOsManager/windows.py
+++ b/server/src/uds/osmanagers/WindowsOsManager/windows.py
@@ -14,6 +14,7 @@ import typing
 from django.utils.translation import gettext_noop as _
 
 from uds.core import osmanagers, types
+from uds.core.managers.userservice import UserServiceManager
 from uds.core.ui import gui
 from uds.core.util import log, fields
 from uds.core.types.states import State
@@ -107,10 +108,12 @@ class WindowsOsManager(osmanagers.OSManager):
             log.log(
                 userservice,
                 types.log.LogLevel.INFO,
-                'Unused user service for too long. Removing due to OS Manager parameters.',
+                'Unused user service for too long. Releasing (logout) due to OS Manager parameters.',
                 types.log.LogSource.OSMANAGER,
             )
-            userservice.release()
+            osmanagers.OSManager.logged_out(userservice, username='unused')
+            # release_from_logout handles cache return if pool allows it, else releases
+            UserServiceManager.manager().release_from_logout(userservice)
 
     def is_persistent(self) -> bool:
         return fields.onlogout_field_is_persistent(self.on_logout)

--- a/server/src/uds/workers/assigned_unused.py
+++ b/server/src/uds/workers/assigned_unused.py
@@ -34,8 +34,9 @@ from datetime import timedelta
 
 from django.db.models import Q, Count
 
-from uds.core import types
+from uds.core import types, osmanagers
 from uds.core.jobs import Job
+from uds.core.managers.userservice import UserServiceManager
 from uds.core.util import log
 from uds.core.util.config import GlobalConfig
 from uds.core.types.states import State
@@ -96,6 +97,8 @@ class AssignedAndUnused(Job):
                         us,
                         types.log.LogLevel.INFO,
                         source=types.log.LogSource.SERVER,
-                        message='Removing unused assigned service',
+                        message='Releasing (logout) unused assigned service',
                     )
-                    us.release()
+                    osmanagers.OSManager.logged_out(us, username='unused')
+                    # release_from_logout handles cache return if pool allows it, else releases
+                    UserServiceManager.manager().release_from_logout(us)


### PR DESCRIPTION
This pull request updates the way unused user services are handled for both Linux and Windows OS managers, as well as within the assigned unused worker. The main change is to replace direct service release calls with a more structured logout and release process, ensuring that the logout event is properly logged and that services are released in a way that supports pool caching if available.

**Refactoring and behavior changes for unused service handling:**

- Both `LinuxOsManager` and `WindowsOsManager` now use `osmanagers.OSManager.logged_out` to log the logout event before releasing the service, instead of calling `userservice.release()` directly. This makes the logout process more explicit and consistent. [[1]](diffhunk://#diff-8ee7b2bdf17b9d8fc220c510b3ab6b840c1568a02a91fdf0725c3a71e526121fL118-R124) [[2]](diffhunk://#diff-99f65399fc8f3a9c51d8314586e1b84592006d713195800176ff90ccf90371c6L110-R116)
- The release logic is now handled by `UserServiceManager.manager().release_from_logout`, which manages whether the service is returned to the cache or fully released, depending on pool configuration. [[1]](diffhunk://#diff-8ee7b2bdf17b9d8fc220c510b3ab6b840c1568a02a91fdf0725c3a71e526121fL118-R124) [[2]](diffhunk://#diff-99f65399fc8f3a9c51d8314586e1b84592006d713195800176ff90ccf90371c6L110-R116)
- The assigned unused worker (`assigned_unused.py`) is updated to use the same logout and release flow, ensuring consistency across the codebase.

**Logging and messaging improvements:**

- Updated log messages to indicate that services are being "released (logout)" rather than simply "removed," providing clearer context in logs. [[1]](diffhunk://#diff-8ee7b2bdf17b9d8fc220c510b3ab6b840c1568a02a91fdf0725c3a71e526121fL118-R124) [[2]](diffhunk://#diff-99f65399fc8f3a9c51d8314586e1b84592006d713195800176ff90ccf90371c6L110-R116) [[3]](diffhunk://#diff-5366b8ac4293f4d8bed338a75273bd9bf887a9223ea6231ca19f206f790a26a7L99-R104)

**Imports and code organization:**

- Added imports for `UserServiceManager` and `osmanagers` in all affected files to support the new logout and release flow. [[1]](diffhunk://#diff-8ee7b2bdf17b9d8fc220c510b3ab6b840c1568a02a91fdf0725c3a71e526121fR39) [[2]](diffhunk://#diff-99f65399fc8f3a9c51d8314586e1b84592006d713195800176ff90ccf90371c6R17) [[3]](diffhunk://#diff-5366b8ac4293f4d8bed338a75273bd9bf887a9223ea6231ca19f206f790a26a7L37-R39)