### PR TITLE
Add MAC address replacement in URL pattern for transport updates

### DIFF
--- a/server/src/uds/transports/URL/url_custom.py
+++ b/server/src/uds/transports/URL/url_custom.py
@@ -119,9 +119,10 @@ class URLCustomTransport(transports.Transport):
         # Fix username/password acording to os manager
         username: str = user.get_username_for_auth()
         username, password = userservice.process_user_password(username, password)
+        mac = userservice.get_unique_id()
 
         return self.update_link_window(
-            self.url_pattern.value.replace('_IP_', ip).replace('_USER_', username),
+            self.url_pattern.value.replace('_IP_', ip).replace('_USER_', username).replace('_MAC_', mac),
             on_same_window=self.force_new_window.value == 'overwrite',
             on_new_window=self.force_new_window.value == 'true',
             uuid=userservice.service_pool.uuid if self.force_new_window.value == 'true' else None,


### PR DESCRIPTION
This pull request updates the URL generation logic in the `get_link` method to support substituting the user's MAC address into the URL pattern. This allows URLs to be customized with the user's unique hardware identifier, improving integration with systems that require MAC-based authentication or tracking.

Enhancement to URL customization:

* Modified `get_link` in `url_custom.py` to retrieve the user's unique MAC address using `userservice.get_unique_id()` and substitute it into the URL pattern by replacing the `_MAC_` placeholder.