### PR TITLE
Adds net filtering to authenticator save fields

### DIFF
--- a/server/src/uds/REST/methods/authenticators.py
+++ b/server/src/uds/REST/methods/authenticators.py
@@ -64,7 +64,7 @@ class Authenticators(ModelHandler):
     # Custom get method "search" that requires authenticator id
     custom_methods = [('search', True)]
     detail = {'users': Users, 'groups': Groups}
-    save_fields = ['name', 'comments', 'tags', 'priority', 'small_name', 'mfa_id:_', 'state']
+    save_fields = ['name', 'comments', 'tags', 'priority', 'small_name', 'mfa_id:_', 'state', 'net_filtering']
 
     table_title = _('Authenticators')
     table_fields = [


### PR DESCRIPTION
This pull request makes a minor update to the `Authenticators` model handler by adding the `net_filtering` field to the list of fields that can be saved. This allows the `net_filtering` attribute to be included when saving authenticator objects.

## Dev Explain
When we clicked save in the network filtering settings, the change was not saved or it reverted to the default.