### PR TITLE
Prevents removal of machines with active user services

### DIFF
--- a/server/src/uds/core/services/generics/fixed/service.py
+++ b/server/src/uds/core/services/generics/fixed/service.py
@@ -151,9 +151,16 @@ class FixedService(services.Service, abc.ABC):  # pylint: disable=too-many-publi
             if not self.machines.value:
                 raise exceptions.ui.ValidationError(gettext('We need at least a machine'))
 
-            # Remove machines not in values from "assigned" set
+            # Do not allow removing machines that still have assigned user services.
+            # (their UserService rows would linger, counting against userservices_limit)
             with self._assigned_access() as assigned_vms:
-                assigned_vms &= set(self.machines.as_list())
+                removed_assigned = assigned_vms - set(self.machines.as_list())
+                if removed_assigned:
+                    raise exceptions.ui.ValidationError(
+                        gettext('Cannot remove machines with assigned services: {}').format(
+                            ', '.join(sorted(removed_assigned))
+                        )
+                    )
             self.token.value = self.token.value.strip()
 
     @contextlib.contextmanager


### PR DESCRIPTION
This pull request introduces a stricter validation when updating the list of assigned machines in the `FixedService` class. Now, it prevents removing any machines that still have assigned user services, which avoids lingering `UserService` records that would incorrectly count against the `userservices_limit`.

Validation improvements:

* Updated the machine removal logic in `service.py` to raise a validation error if an attempt is made to remove machines that still have assigned user services, ensuring data consistency and preventing orphaned `UserService` rows.