### PR TITLE
Improves properties lookup for user service assignments on metapools

### DIFF
--- a/server/src/uds/REST/methods/meta_service_pools.py
+++ b/server/src/uds/REST/methods/meta_service_pools.py
@@ -29,6 +29,7 @@
 """
 Author: Adolfo Gómez, dkmaster at dkmon dot com
 """
+import collections
 import logging
 import typing
 
@@ -171,13 +172,12 @@ class MetaAssignedService(DetailHandler):
             ]
         ):
             for m in parent.members.filter(enabled=True):
-                properties: dict[str, typing.Any] = {
-                    k: v
-                    for k, v in models.Properties.objects.filter(
-                        owner_type='userservice',
-                        owner_id__in=m.pool.assigned_user_services().values_list('uuid', flat=True),
-                    ).values_list('key', 'value')
-                }
+                properties: dict[str, dict[str, typing.Any]] = collections.defaultdict(dict)
+                for id, key, value in models.Properties.objects.filter(
+                    owner_type='userservice',
+                    owner_id__in=m.pool.assigned_user_services().values_list('uuid', flat=True),
+                ).values_list('owner_id', 'key', 'value'):
+                    properties[id][key] = value
                 for u in (
                     m.pool.assigned_user_services()
                     .filter(state__in=State.VALID_STATES)


### PR DESCRIPTION
This pull request refactors how properties for user services are collected within the `meta_service_pools` REST method. The main change is the use of a `defaultdict` to group properties by user service ID, improving data structure and lookup efficiency.

**Refactoring and data structure improvements:**

* Replaced a flat dictionary with a `collections.defaultdict(dict)` for the `properties` variable, allowing properties to be grouped by user service ID for easier access and improved organization.
* Added the `collections` module import to support the use of `defaultdict`.