### PR TITLE
Corrects 'is_avaliable' typo to 'is_available'

### DIFF
--- a/server/src/uds/core/managers/userservice.py
+++ b/server/src/uds/core/managers/userservice.py
@@ -741,7 +741,7 @@ class UserServiceManager(metaclass=singleton.Singleton):
             )
             or service_pool.service.provider.is_in_maintenance()
             or service_pool.is_restrained()
-            or not service_instance.is_avaliable()
+            or not service_instance.is_available()
         ):
             return False
 
@@ -1243,7 +1243,7 @@ class UserServiceManager(metaclass=singleton.Singleton):
             if meta.ha_policy == types.pools.HighAvailabilityPolicy.ENABLED:
                 # Check that servide is accessible
                 if (
-                    not already_assigned.deployed_service.service.get_instance().is_avaliable()
+                    not already_assigned.deployed_service.service.get_instance().is_available()
                 ):  # Not available, mark for removal
                     already_assigned.release()
                 raise Exception()  # And process a new access
@@ -1267,7 +1267,7 @@ class UserServiceManager(metaclass=singleton.Singleton):
             for pool in pools:  # Pools are already sorted, and "full" pools are filtered out
                 if meta.ha_policy == types.pools.HighAvailabilityPolicy.ENABLED:
                     # If not available, skip it
-                    if pool.service.get_instance().is_avaliable() is False:
+                    if pool.service.get_instance().is_available() is False:
                         continue
 
                 # Ensure transport is available for the OS

--- a/server/src/uds/core/services/service.py
+++ b/server/src/uds/core/services/service.py
@@ -265,7 +265,7 @@ class Service(Module):
         """
         return self._provider
 
-    def is_avaliable(self) -> bool:
+    def is_available(self) -> bool:
         """
         Returns if this service is reachable (that is, we can operate with it). This is used, for example, to check
         if a service is "operable" before removing an user service (pass from "waiting for removal" to "removing")

--- a/server/src/uds/services/OVirt/service_linked.py
+++ b/server/src/uds/services/OVirt/service_linked.py
@@ -338,7 +338,7 @@ class OVirtLinkedService(services.Service):  # pylint: disable=too-many-public-m
     def get_console_connection(self, vmid: str) -> typing.Optional[types.services.ConsoleConnectionInfo]:
         return self.provider().api.get_console_connection_info(vmid)
 
-    def is_avaliable(self) -> bool:
+    def is_available(self) -> bool:
         return self.provider().is_available()
 
     def try_graceful_shutdown(self) -> bool:

--- a/server/src/uds/services/OpenGnsys/service.py
+++ b/server/src/uds/services/OpenGnsys/service.py
@@ -203,5 +203,5 @@ class OGService(services.Service):
     def try_start_if_unavailable(self) -> bool:
         return self.start_if_unavailable.as_bool()
 
-    def is_avaliable(self) -> bool:
+    def is_available(self) -> bool:
         return self.provider().is_available()

--- a/server/src/uds/services/OpenNebula/service.py
+++ b/server/src/uds/services/OpenNebula/service.py
@@ -310,5 +310,5 @@ class OpenNebulaLiveService(services.Service):
     ) -> typing.Optional[types.services.ConsoleConnectionInfo]:
         return self.provider().desktop_login(vmid, username, password, domain)
 
-    def is_avaliable(self) -> bool:
+    def is_available(self) -> bool:
         return self.provider().is_available()

--- a/server/src/uds/services/OpenStack/service.py
+++ b/server/src/uds/services/OpenStack/service.py
@@ -356,5 +356,5 @@ class OpenStackLiveService(DynamicService):
             security_groups_names=self.security_groups.value,
         )
 
-    def is_avaliable(self) -> bool:
+    def is_available(self) -> bool:
         return self.provider().is_available()

--- a/server/src/uds/services/OpenStack/service_fixed.py
+++ b/server/src/uds/services/OpenStack/service_fixed.py
@@ -146,7 +146,7 @@ class OpenStackServiceFixed(FixedService):  # pylint: disable=too-many-public-me
     def provider(self) -> 'AnyOpenStackProvider':
         return typing.cast('AnyOpenStackProvider', super().provider())
 
-    def is_avaliable(self) -> bool:
+    def is_available(self) -> bool:
         return self.provider().is_available()
 
     def enumerate_assignables(self) -> collections.abc.Iterable[types.ui.ChoiceItem]:

--- a/server/src/uds/services/PhysicalMachines/service_multi.py
+++ b/server/src/uds/services/PhysicalMachines/service_multi.py
@@ -279,5 +279,5 @@ class IPMachinesService(services.Service):
 
     # Phisical machines does not have "real" providers, so
     # always is available
-    def is_avaliable(self) -> bool:
+    def is_available(self) -> bool:
         return True

--- a/server/src/uds/services/PhysicalMachines/service_single.py
+++ b/server/src/uds/services/PhysicalMachines/service_single.py
@@ -121,5 +121,5 @@ class IPSingleMachineService(services.Service):
 
     # Phisical machines does not have "real" providers, so
     # always is available
-    def is_avaliable(self) -> bool:
+    def is_available(self) -> bool:
         return True

--- a/server/src/uds/services/Xen/service.py
+++ b/server/src/uds/services/Xen/service.py
@@ -216,7 +216,7 @@ class XenLinkedService(DynamicService):  # pylint: disable=too-many-public-metho
                     )
                 )
 
-    def is_avaliable(self) -> bool:
+    def is_available(self) -> bool:
         return self.provider().is_available()
 
     def sanitized_name(self, name: str) -> str:

--- a/server/src/uds/services/Xen/service_fixed.py
+++ b/server/src/uds/services/Xen/service_fixed.py
@@ -164,7 +164,7 @@ class XenFixedService(FixedService):  # pylint: disable=too-many-public-methods
 
         return ''  # Already stopped
 
-    def is_avaliable(self) -> bool:
+    def is_available(self) -> bool:
         return self.provider().is_available()
 
     def enumerate_assignables(self) -> collections.abc.Iterable[types.ui.ChoiceItem]:

--- a/server/tests/services/openstack/test_service.py
+++ b/server/tests/services/openstack/test_service.py
@@ -102,7 +102,7 @@ class TestOpenstackService(UDSTransactionTestCase):
                 service.api.delete_server(server.id)
                 api.delete_server.assert_called_once_with(server.id)
 
-                self.assertTrue(service.is_avaliable())
+                self.assertTrue(service.is_available())
                 api.is_available.assert_called_once_with()
 
                 self.assertEqual(service.get_basename(), service.basename.value)

--- a/server/tests/services/openstack/test_service_fixed.py
+++ b/server/tests/services/openstack/test_service_fixed.py
@@ -53,7 +53,7 @@ class TestOpenstackFixedService(UDSTransactionTestCase):
                 userservice = fixtures.create_fixed_userservice(service)
 
                 # Test service is_available method
-                self.assertTrue(service.is_avaliable())
+                self.assertTrue(service.is_available())
                 api.is_available.assert_called()
 
                 # assignables should be same as service.macines

--- a/server/tests/services/ovirt/test_service_linked.py
+++ b/server/tests/services/ovirt/test_service_linked.py
@@ -59,17 +59,17 @@ class TestProxmovLinkedService(UDSTestCase):
         with fixtures.patch_provider_api() as api:
             service = fixtures.create_linked_service()
 
-            self.assertTrue(service.is_avaliable())
+            self.assertTrue(service.is_available())
             api.test.assert_called_with()
             # With data cached, even if test fails, it will return True
             api.test.return_value = False
-            self.assertTrue(service.is_avaliable())
+            self.assertTrue(service.is_available())
 
             # Data is cached, so we need to reset it
             api.test.reset_mock()
             service.provider().is_available.cache_clear()  # type: ignore
             # Now should return False as we have reset the cache
-            self.assertFalse(service.is_avaliable())
+            self.assertFalse(service.is_available())
             api.test.assert_called_with()
 
     def test_verify_free_storage(self) -> None:

--- a/server/tests/services/physical_machines/test_service_multi.py
+++ b/server/tests/services/physical_machines/test_service_multi.py
@@ -68,7 +68,7 @@ class TestServiceMulti(UDSTransactionTestCase):
         Test the provider
         """
         service = fixtures.create_service_multi()
-        self.assertTrue(service.is_avaliable())  # Always available
+        self.assertTrue(service.is_available())  # Always available
 
     def test_wakeup(self) -> None:
         # Patch security.secure_requests_session

--- a/server/tests/services/physical_machines/test_service_single.py
+++ b/server/tests/services/physical_machines/test_service_single.py
@@ -48,7 +48,7 @@ class TestService(UDSTransactionTestCase):
         Test the provider
         """
         service = fixtures.create_service_single()
-        self.assertTrue(service.is_avaliable())  # Always available
+        self.assertTrue(service.is_available())  # Always available
 
     def test_wakeup(self) -> None:
         # Patch security.secure_requests_session

--- a/server/tests/services/proxmox/test_service_fixed.py
+++ b/server/tests/services/proxmox/test_service_fixed.py
@@ -53,17 +53,17 @@ class TestProxmoxFixedService(UDSTransactionTestCase):
             api = typing.cast(mock.MagicMock, provider.api)
             service = fixtures.create_service_fixed(provider=provider)
 
-            self.assertTrue(service.is_avaliable())
+            self.assertTrue(service.is_available())
             api.test.assert_called_with()
             # With data cached, even if test fails, it will return True
             api.test.return_value = False
-            self.assertTrue(service.is_avaliable())
+            self.assertTrue(service.is_available())
 
             # Data is cached, so we need to reset it
             api.test.reset_mock()
             service.provider().is_available.cache_clear()  # type: ignore
             # Now should return False as we have reset the cache
-            self.assertFalse(service.is_avaliable())
+            self.assertFalse(service.is_available())
             api.test.assert_called_with()
 
     def test_service_methods_1(self) -> None:

--- a/server/tests/services/proxmox/test_service_linked.py
+++ b/server/tests/services/proxmox/test_service_linked.py
@@ -61,17 +61,17 @@ class TestProxmovLinkedService(UDSTestCase):
             api = typing.cast(mock.MagicMock, provider.api)
             service = fixtures.create_service_linked(provider=provider)
 
-            self.assertTrue(service.is_avaliable())
+            self.assertTrue(service.is_available())
             api.test.assert_called_with()
             # With data cached, even if test fails, it will return True
             api.test.return_value = False
-            self.assertTrue(service.is_avaliable())
+            self.assertTrue(service.is_available())
 
             # Data is cached, so we need to reset it
             api.test.reset_mock()
             service.provider().is_available.cache_clear()  # type: ignore
             # Now should return False as we have reset the cache
-            self.assertFalse(service.is_avaliable())
+            self.assertFalse(service.is_available())
             api.test.assert_called_with()
             
     def test_service_is_deleted(self) -> None:
@@ -159,4 +159,4 @@ class TestProxmovLinkedService(UDSTestCase):
             self.assertEqual(service.get_console_connection('1'), fixtures.CONSOLE_CONNECTION_INFO)
 
             # Is available
-            self.assertTrue(service.is_avaliable())
+            self.assertTrue(service.is_available())

--- a/server/tests/services/xen/test_service_fixed.py
+++ b/server/tests/services/xen/test_service_fixed.py
@@ -55,17 +55,17 @@ class TestXenFixedService(UDSTransactionTestCase):
             api = typing.cast(mock.MagicMock, provider.api)
             service = fixtures.create_service_fixed(provider=provider)
 
-            self.assertTrue(service.is_avaliable())
+            self.assertTrue(service.is_available())
             api.test.assert_called_with()
             # With data cached, even if test fails, it will return True
             api.test.side_effect = Exception('Testing exception')
-            self.assertTrue(service.is_avaliable())
+            self.assertTrue(service.is_available())
 
             # Data is cached, so we need to reset it
             api.test.reset_mock()
             service.provider().is_available.cache_clear()  # type: ignore
             # Now should return False as we have reset the cache
-            self.assertFalse(service.is_avaliable())
+            self.assertFalse(service.is_available())
             api.test.assert_called_with()
 
     def test_service_vm_methods(self) -> None:

--- a/server/tests/services/xen/test_service_linked.py
+++ b/server/tests/services/xen/test_service_linked.py
@@ -84,17 +84,17 @@ class TestXenLinkedService(UDSTestCase):
             api = typing.cast(mock.MagicMock, provider.api)
             service = fixtures.create_service_linked(provider=provider)
 
-            self.assertTrue(service.is_avaliable())
+            self.assertTrue(service.is_available())
             api.test.assert_called_with()
             # With data cached, even if test fails, it will return True
             api.test.side_effect = Exception('Testing exception')
-            self.assertTrue(service.is_avaliable())
+            self.assertTrue(service.is_available())
 
             # Data is cached, so we need to reset it
             api.test.reset_mock()
             service.provider().is_available.cache_clear()  # type: ignore
             # Now should return False as we have reset the cache
-            self.assertFalse(service.is_avaliable())
+            self.assertFalse(service.is_available())
             api.test.assert_called_with()
 
     def test_start_deploy_of_template(self) -> None:


### PR DESCRIPTION
Unifies method naming across services and tests for consistency and clarity by renaming all occurrences of the misspelled 'is_avaliable' to the correct 'is_available'.

Prevents confusion and potential integration issues stemming from inconsistent method names.