### PR TITLE
Corrects method name typo in availability checks

### DIFF
--- a/server/src/uds/services/Proxmox/service.py
+++ b/server/src/uds/services/Proxmox/service.py
@@ -278,7 +278,7 @@ class ProxmoxService(DynamicService):
     def get_console_connection(self, vmid: str) -> types.services.ConsoleConnectionInfo | None:
         return self.provider().api.get_console_connection(int(vmid))
 
-    def is_available(self) -> bool:
+    def is_avaliable(self) -> bool:
         return self.provider().is_available()
 
     def get_ip(self, caller_instance: 'DynamicUserService | DynamicPublication | None', vmid: str) -> str:

--- a/server/src/uds/services/Proxmox/service_fixed.py
+++ b/server/src/uds/services/Proxmox/service_fixed.py
@@ -118,7 +118,7 @@ class ProxmoxServiceFixed(FixedService):  # pylint: disable=too-many-public-meth
     def get_console_connection(self, vmid: str) -> types.services.ConsoleConnectionInfo | None:
         return self.provider().api.get_console_connection(int(vmid))
 
-    def is_available(self) -> bool:
+    def is_avaliable(self) -> bool:
         return self.provider().is_available()
 
     def get_vm_info(self, vmid: int) -> 'prox_types.VMInfo':


### PR DESCRIPTION
This pull request makes a minor change to the Proxmox service classes by renaming the method `is_available` to `is_avaliable` in both `service.py` and `service_fixed.py` to maintain consistency.

- Method renaming for consistency:
  * Renamed `is_available` to `is_avaliable` in the `Proxmox` service implementation (`server/src/uds/services/Proxmox/service.py`).
  * Renamed `is_available` to `is_avaliable` in the fixed Proxmox service implementation (`server/src/uds/services/Proxmox/service_fixed.py`).

## DEV Explain
In metapools, if a Proxmox provider went down, changing the name correctly didn't work properly.