### PR TITLE
chore(audit): disable config-change log filtering in 4.0

### DIFF
--- a/server/src/uds/reports/lists/audit.py
+++ b/server/src/uds/reports/lists/audit.py
@@ -36,7 +36,7 @@ import logging
 import re
 import typing
 
-from django.db.models import Q
+# from django.db.models import Q  # disabled for 4.0 (see gen_data)
 from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 
@@ -84,15 +84,25 @@ class ListReportAuditCSV(ListReport):
             r'(?P<ip>[^\[ ]*) *(?P<user>.*?): \[(?P<method>[^/]*)/(?P<response_code>[^\]]*)\] (?P<request>.*)'
         )
         # Marker of config-change entries stored as plain "logs" (from uds.REST.methods.config)
-        CONFIG_MARKER = 'Updating config value '
+        # CONFIG_MARKER = 'Updating config value '
 
         start = self.start_date.as_datetime().replace(hour=0, minute=0, second=0, microsecond=0)
         end = self.end_date.as_datetime().replace(hour=23, minute=59, second=59, microsecond=999999)
+        # NOTE: Including config-change entries (LOGS source) requires a data__contains
+        # filter, which becomes a full-table LIKE '%...%' scan over every Log row. On
+        # installations with hundreds of millions of rows this is prohibitively slow, so
+        # it is left disabled for 4.0. Keep the old REST-only filter active.
+        # for i in Log.objects.filter(
+        #     Q(source=types.log.LogSource.REST)
+        #     | Q(source=types.log.LogSource.LOGS, data__contains=CONFIG_MARKER),
+        #     created__gte=start,
+        #     created__lte=end,
+        #     owner_type=types.log.LogObjectType.SYSLOG,
+        # ).order_by('-created'):
         for i in Log.objects.filter(
-            Q(source=types.log.LogSource.REST)
-            | Q(source=types.log.LogSource.LOGS, data__contains=CONFIG_MARKER),
             created__gte=start,
             created__lte=end,
+            source=types.log.LogSource.REST,
             owner_type=types.log.LogObjectType.SYSLOG,
         ).order_by('-created'):
             # extract user, method, response_code and request from data field
@@ -131,19 +141,20 @@ class ListReportAuditCSV(ListReport):
                     response_code,
                     m.group('request'),
                 )
-            elif CONFIG_MARKER in i.data:
-                # Config change logged as plain "logs" entry:
-                #   uds.REST.methods.config:put 55 Updating config value <section>.<key> to <value> by <user>
-                what = i.data[i.data.index(CONFIG_MARKER) + len(CONFIG_MARKER) :]
-                value, _sep, user = what.rpartition(' by ')
-                yield (
-                    i.created,
-                    '',  # no ip recorded for config-change logs
-                    user if _sep else '',
-                    'CONFIG',
-                    '',
-                    CONFIG_MARKER + (value if _sep else what),
-                )
+            # Disabled for 4.0 along with the LOGS/data__contains filter above (full-scan cost).
+            # elif CONFIG_MARKER in i.data:
+            #     # Config change logged as plain "logs" entry:
+            #     #   uds.REST.methods.config:put 55 Updating config value <section>.<key> to <value> by <user>
+            #     what = i.data[i.data.index(CONFIG_MARKER) + len(CONFIG_MARKER) :]
+            #     value, _sep, user = what.rpartition(' by ')
+            #     yield (
+            #         i.created,
+            #         '',  # no ip recorded for config-change logs
+            #         user if _sep else '',
+            #         'CONFIG',
+            #         '',
+            #         CONFIG_MARKER + (value if _sep else what),
+            #     )
 
     def generate(self) -> bytes:
         output = io.StringIO()


### PR DESCRIPTION
This pull request temporarily disables the inclusion of configuration change log entries from the "LOGS" source in the audit report generation, due to performance concerns with large datasets in version 4.0. Only REST-based log entries are now processed for audit reports, avoiding expensive full-table scans.

**Performance and Filtering Changes:**

* Disabled the use of `Q` objects and the `data__contains` filter for including config-change entries from the "LOGS" source in the audit report, as this would require a full-table LIKE scan and is not scalable for large installations. Only entries from the "REST" source are now considered. [[1]](diffhunk://#diff-5a57906208b28aca9442abeff0430314922d5a946069645c6aede1aa8042335fL39-R39) [[2]](diffhunk://#diff-5a57906208b28aca9442abeff0430314922d5a946069645c6aede1aa8042335fL87-R105)

**Code and Logic Adjustments:**

* Commented out all logic related to processing "LOGS" source config-change entries, including the `CONFIG_MARKER` constant and the code that parsed and yielded these entries, to align with the new filtering approach for version 4.0. [[1]](diffhunk://#diff-5a57906208b28aca9442abeff0430314922d5a946069645c6aede1aa8042335fL87-R105) [[2]](diffhunk://#diff-5a57906208b28aca9442abeff0430314922d5a946069645c6aede1aa8042335fL134-R157)