### PR TITLE
test: repair proxmox and dynamic service test doubles after renames

### DIFF
--- a/server/tests/core/services/generics/fixtures.py
+++ b/server/tests/core/services/generics/fixtures.py
@@ -486,7 +486,7 @@ class DynamicTestingService(dynamic_service.DynamicService):
         caller_instance: typing.Optional[dynamic_userservice.DynamicUserService | dynamic_publication.DynamicPublication],
         vmid: str,
         *,
-        force_new: bool = False,
+        for_unique_id: bool = False,
     ) -> str:
         self.mock.get_mac(caller_instance, vmid)
         return '02:04:06:08:0A:0C'
@@ -689,7 +689,7 @@ class DynamicTestingServiceForDeferredDeletion(dynamic_service.DynamicService):
         caller_instance: typing.Optional[dynamic_userservice.DynamicUserService | dynamic_publication.DynamicPublication],
         vmid: str,
         *,
-        force_new: bool = False,
+        for_unique_id: bool = False,
     ) -> str:
         return ''
 

--- a/server/tests/services/proxmox/fixtures.py
+++ b/server/tests/services/proxmox/fixtures.py
@@ -54,7 +54,7 @@ from uds.services.Proxmox import (
     service_fixed,
     publication,
     deployment_fixed,
-    service_linked,
+    service,
 )
 
 from uds.services.Proxmox.proxmox import types as prox_types, exceptions as prox_exceptions
@@ -513,7 +513,7 @@ PROVIDER_VALUES_DICT: gui.ValuesDictType = {
     'concurrent_removal_limit': 1,
     'timeout': 10,
     'start_vmid': 100,
-    'macs_range': '00:00:00:00:00:00-00:00:00:ff:ff:ff',
+    'macs_range': '00:00:00:00:00:01-00:00:00:ff:ff:ff',
 }
 
 
@@ -550,10 +550,13 @@ def create_client_mock() -> mock.Mock:
 def patched_provider(
     **kwargs: typing.Any,
 ) -> typing.Generator[provider.ProxmoxProvider, None, None]:
-    client = create_client_mock()
-    provider = create_provider(**kwargs)
-    provider._cached_api = client
-    yield provider
+    yield create_mocked_provider(**kwargs)
+
+
+def create_mocked_provider(**kwargs: typing.Any) -> provider.ProxmoxProvider:
+    prov = create_provider(**kwargs)
+    prov._cached_api = create_client_mock()
+    return prov
 
 
 def create_provider(**kwargs: typing.Any) -> provider.ProxmoxProvider:
@@ -565,22 +568,22 @@ def create_provider(**kwargs: typing.Any) -> provider.ProxmoxProvider:
 
     uuid_ = str(uuid.uuid4())
     return provider.ProxmoxProvider(
-        environment=environment.Environment.private_environment(uuid), values=values, uuid=uuid_
+        environment=environment.Environment.private_environment(uuid_), values=values, uuid=uuid_
     )
 
 
 def create_service_linked(
     provider: typing.Optional[provider.ProxmoxProvider] = None, **kwargs: typing.Any
-) -> service_linked.ProxmoxServiceLinked:
+) -> service.ProxmoxService:
     """
     Create a fixed service
     """
     uuid_ = str(uuid.uuid4())
     values = SERVICE_LINKED_VALUES_DICT.copy()
     values.update(kwargs)
-    srvc = service_linked.ProxmoxServiceLinked(
+    srvc = service.ProxmoxService(
         environment=environment.Environment.private_environment(uuid_),
-        provider=provider or create_provider(),
+        provider=provider or create_mocked_provider(),
         values=values,
         uuid=uuid_,
     )
@@ -605,14 +608,14 @@ def create_service_fixed(
     values.update(kwargs)
     return service_fixed.ProxmoxServiceFixed(
         environment=environment.Environment.private_environment(uuid_),
-        provider=provider or create_provider(),
+        provider=provider or create_mocked_provider(),
         values=values,
         uuid=uuid_,
     )
 
 
 def create_publication(
-    service: typing.Optional[service_linked.ProxmoxServiceLinked] = None,
+    service: typing.Optional[service.ProxmoxService] = None,
     **kwargs: typing.Any,
 ) -> 'publication.ProxmoxPublication':
     """
@@ -647,7 +650,7 @@ def create_userservice_fixed(
 
 
 def create_userservice_linked(
-    service: typing.Optional[service_linked.ProxmoxServiceLinked] = None,
+    service: typing.Optional[service.ProxmoxService] = None,
     publication: typing.Optional['publication.ProxmoxPublication'] = None,
 ) -> deployment_linked.ProxmoxUserserviceLinked:
     """

--- a/server/tests/services/proxmox/test_service_fixed.py
+++ b/server/tests/services/proxmox/test_service_fixed.py
@@ -152,7 +152,7 @@ class TestProxmoxFixedService(UDSTransactionTestCase):
             fixtures.SNAPSHOTS_INFO.clear()
             service.snapshot_creation(userservice_instance)
             api.get_current_vm_snapshot.assert_called_with(int(vmid))
-            api.create_snapshot.assert_called_with(int(vmid), name='UDS Snapshot')
+            api.create_snapshot.assert_called_with(int(vmid), name='UDS_Snapshot')
 
             # Skip snapshot creation
             api.reset_mock()


### PR DESCRIPTION
Test-only changes. No production code is touched.

## What was broken

`tests/services/proxmox` did not even import:

```
ImportError: cannot import name 'service_linked' from 'uds.services.Proxmox'
```

`service_linked.py` was renamed to `service.py` (and `ProxmoxServiceLinked` to `ProxmoxService`) without updating the fixtures.

With collection restored, five more failures showed up underneath, plus seven in `tests/core/services/generics/test_dynamic_service.py` that were failing on their own:

| Failure | Cause |
|---|---|
| 7 x `TaskState.ERROR != RUNNING` in `test_dynamic_service.py` | The test doubles still declared `get_mac(..., force_new=...)`, renamed to `for_unique_id` in `DynamicService`. The `TypeError` was swallowed and surfaced as an ERROR state |
| 4 x `No more MACs available` | The provider fixture mac range started at `00:00:00:00:00:00`, which is the `NO_MORE_MACS` sentinel, so the first generated mac read as "no macs left". 5.0 already starts at `...:01` |
| `test_process_snapshot` | Asserted `name='UDS Snapshot'` while the service creates `'UDS_Snapshot'` |
| Network calls from unit tests | `create_service_linked()` built a real provider, and service initialization validates the storage against the API, so the tests reached out to `host:8006` |

## What this changes

- `tests/services/proxmox/fixtures.py`: import and type references updated; `create_mocked_provider()` extracted from `patched_provider` so the `create_service_*` helpers get a mocked client instead of a real provider; mac range starts at `...:01`; `private_environment()` receives the generated uuid instead of the `uuid` module.
- `tests/services/proxmox/test_service_fixed.py`: snapshot name assertion.
- `tests/core/services/generics/fixtures.py`: `force_new` renamed to `for_unique_id` in the two `get_mac` doubles.

## Testing

```
tests/services/proxmox + tests/core/services/generics   ->  74 passed, 32 skipped
tests --ignore=tests/enterprise                         -> 469 passed, 72 skipped, 3 failed
```

The three remaining failures are unrelated to this branch and come from the enterprise plugin not being wired into this checkout: `test_transports_loads_correctly` (`nicedcvtunneltransport` missing), `test_jobs_stores_on_db` (28 jobs instead of 34) and `physical_machines/test_migration::test_migrate`.
