### PR TITLE
Do not depend on DNS in the physical machines migration test

### DIFF
--- a/server/tests/services/physical_machines/test_migration.py
+++ b/server/tests/services/physical_machines/test_migration.py
@@ -215,7 +215,7 @@ STORAGE_DATA: typing.Final[list[dict[str, typing.Any]]] = [
     {
         'owner': 't-service-144',
         'key': '848d16fb421048c690c9761c11dc1699',
-        'data': 'gASVUwAAAAAAAABdlCiMHzE3Mi4yNy4xLjI1OzAxOjIzOjQ1OjY3Ojg5OkFCfjGUjA0xNzIuMjcuMS4yNn4xlIwNMTcyLjI3LjEuMjd+MpSMCWxvY2FsaG9zdJRlLg==',
+        'data': 'gASVRwAAAAAAAABdlCiMHzE3Mi4yNy4xLjI1OzAxOjIzOjQ1OjY3Ojg5OkFCfjGUjA0xNzIuMjcuMS4yNn4xlIwNMTcyLjI3LjEuMjd+MpRlLg==',
         'attr1': '',
     },
     {'owner': 't-service-142', 'key': 'b6ac33477ae0a82fa2681c4d398d88d7', 'data': 'gARLAS4=\n', 'attr1': ''},
@@ -282,11 +282,12 @@ class TestPhysicalMigration(UDSTransactionTestCase):
         #    - 172.27.1.25
         #    - 172.27.1.26
         #    - 172.27.1.27
-        #    - localhost;01:23:45:67:89:AB
         #  - One service pool
         #  - Two user services
         #    * First one, is localhost
         #    * Second one is 172.27.1.26
+        # Note: On GitHub automated tests, localhost CAN be resolved, so i have removed it from the list of ips to add
+        # So test is valid for both cases
 
         # First, proceed to migration of data
         physical_machine_multiple.migrate(self.apps_mock(), None)
@@ -319,11 +320,14 @@ class TestPhysicalMigration(UDSTransactionTestCase):
             )
             self.assertIn(server.ip, ips_to_check, f'Invalid server ip {server.ip}: {ips_to_check}')
             ips_to_check.remove(server.ip)
+
+            # Note: to this to work, reverse dns for
+            # 172.27.1.25-27 must be configured on the system where tests are run
+            # If not, the test will fail
             # Ensure has a hostname, and MAC is empty
-            self.assertNotEqual(server.hostname, '')
+            # self.assertNotEqual(server.hostname, '')
 
             # 172.27.1.25 has a MAC, rest of servers have MAC_UNKNOWN (empty equivalent)
-            # Also, should have 127.0.0.1 as ip if localhost
             if server.ip == '172.27.1.25':
                 self.assertEqual(server.mac, '01:23:45:67:89:AB')
             else:


### PR DESCRIPTION
The test assumed localhost would not resolve, but systemd-resolved synthesises it, so four servers came out where three were expected; it also asserted a non-empty hostname, which only holds where the internal reverse zone is reachable. Removes localhost from the fixture and comments out the hostname assertion, the same as already done in master.